### PR TITLE
Fix method calls in BreadcrumbService

### DIFF
--- a/src/BreadcrumbService.php
+++ b/src/BreadcrumbService.php
@@ -27,8 +27,8 @@ class BreadcrumbService
             $breadcrumbs = self::getParentPages($entry);
 
             // check for mounting page and if so get parent pages of it as well
-            if ($entry->collection->mount() !== null) {
-                $mountEntry = $entry->collection->mount()->in($entry->locale());
+            if ($entry->collection()->mount() !== null) {
+                $mountEntry = $entry->collection()->mount()->in($entry->locale());
             }
 
             if (isset($mountEntry)) {
@@ -77,8 +77,8 @@ class BreadcrumbService
         $breadcrumbs[] = self::mapBreadcrumbEntry($entry);
 
         // parent pages
-        while ($entry->parent) {
-            $parent = $entry->parent;
+        while ($entry->parent()) {
+            $parent = $entry->parent();
             $breadcrumbs[] = [
                 'id' => $parent->id(),
                 'title' => $parent->title,


### PR DESCRIPTION
# Pull request

A call to `$entry->parent` returns an AugmentedCollection in Statamic v6. $entry->collection() instead of $entry->collection (which is a protected property). I think it should always have been a method call - even in Statamic v5.

## Creators Checklist

Thanks for your Contribution 🎉

Before you request a review, please check the following:

- [ ] If you worked on a Jira Task: did you move the task to the review state?
- [ ] If you worked on a Jira Task: did you name the PR containing the task ID?
- [ ] Did you fullfill the business case? (Check the Jira task again to be sure).
- [ ] Did you cleanup your codebase (remove unused and commented code, remove dumps, [ray usages](https://github.com/Napp/xray-laravel) and console logs)?
- [ ] If needed: did you write any tests and do they pass?
- [ ] Did you push the latest changes?
- [ ] Did you check for merge conflicts?

## Reviewers Checklist

This list should help you to review your pull request:
- [ ] Did you check the code is readable and maintainable (complexity!)?
- [ ] Did you check code and comments for typos?
- [ ] If possible: did you check the code matches the requested business case?
- [ ] Did all tests pass?
- [ ] For big PRs: Did you smoke test it in your local test environment?

**After the PR is merged:**
- [ ] Did you delete the PR branch?
- [ ] Did you mark the Jira task as done?
- [ ] Was the deployment successful?




<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix property access to use method calls in `BreadcrumbService`
> Corrects incorrect direct property access in [BreadcrumbService.php](https://github.com/teamnovu/statamic-graphql-breadcrumbs-addon/pull/3/files#diff-cae7c476e223f1d1d1825b5801c73da877b416e9c83c301bbe389f6a0dd60dea) by replacing it with proper method calls. `$entry->collection->mount()` becomes `$entry->collection()->mount()`, and `$entry->parent` becomes `$entry->parent()` in the parent traversal loop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42aefe3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->