### PR TITLE
Fix localized homepage breadcrumb lookup

### DIFF
--- a/src/BreadcrumbService.php
+++ b/src/BreadcrumbService.php
@@ -148,8 +148,8 @@ class BreadcrumbService
 
         // Get the Homepage entry
         $homepage = Entry::query()
-            ->where('url', '/')
-            ->where('locale', $entry->locale())
+            ->where('uri', '/')
+            ->where('site', $entry->locale())
             ->first();
 
         // Add the homepage to the beginning of the breadcrumbs


### PR DESCRIPTION
Fixes #4.

This changes the navigation-based homepage lookup to use the Statamic entry URI scoped to the current site.

Localized home entries keep `uri` as `/`, while their rendered URL is site-prefixed, for example `/nl` or `/hu`. Querying for `url = /` can therefore miss the localized home entry, so breadcrumbs start below home.

Validation:
- `git diff --check`
- verified in a downstream Statamic project with regression cases for localized `/nl` and `/hu` home breadcrumbs

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix homepage entry lookup in `BreadcrumbService.getBreadcrumbs` for localized sites
> Corrects the query filters used to find the homepage entry in [BreadcrumbService.php](https://github.com/teamnovu/statamic-graphql-breadcrumbs-addon/pull/5/files#diff-cae7c476e223f1d1d1825b5801c73da877b416e9c83c301bbe389f6a0dd60dea), changing `url='/'` to `uri='/'` and `locale` to `site` so the correct entry is matched and prepended to the breadcrumbs on localized sites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21c8509.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->